### PR TITLE
Support for PRF importing

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -11,3 +11,8 @@ args:
         short: i
         multiple: false
         about: Enables info logs
+    - reg:
+        long: reg
+        multiple: false
+        about: Imports registers from specified file
+        takes_value: true

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,12 @@ fn main() {
     let yaml = load_yaml!("cli.yaml");
     let matches = App::from(yaml).get_matches();
     let location = matches.value_of("FILE").unwrap();
-    let register_file_location = matches.value_of("reg").unwrap();
+    let mut register_file_location = "";
 
-
-
+    if let Some(x) = matches.value_of("reg") {
+        register_file_location = x;
+    }
+    println!("{}",register_file_location);
     let info_log_filter = match matches.is_present("loginfo") {
         true => LevelFilter::Info,
         _ => LevelFilter::Off,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,12 +15,12 @@ mod debug;
 mod label;
 
 fn main() {
-    let mut location = "";
     let yaml = load_yaml!("cli.yaml");
     let matches = App::from(yaml).get_matches();
-    if let Some(x) = matches.value_of("FILE") {
-        location = x;
-    }
+    let location = matches.value_of("FILE").unwrap();
+    let register_file_location = matches.value_of("reg").unwrap();
+
+
 
     let info_log_filter = match matches.is_present("loginfo") {
         true => LevelFilter::Info,
@@ -55,9 +55,16 @@ fn main() {
         .unwrap()
         .bytes()
         .map(|ch| ch.unwrap());
+
     let mut vm = VM::new();
     for i in file {
         vm.program.append(&mut vec![i]);
+    }
+    if register_file_location != "" {
+        let mut buffer = String::new();
+        std::fs::File::open(register_file_location).unwrap().read_to_string(&mut buffer).unwrap();
+        println!("{}",buffer);
+        register::register_from_string(&buffer, &mut vm.registers)
     }
     vm.run();
     info!("process used {} register(s)", vm.get_register_usage());

--- a/src/register.rs
+++ b/src/register.rs
@@ -35,6 +35,18 @@ impl REGISTER {
     }
 }
 
+fn register_from_string(s: &str, reg_array: *[REGISTER]) {
+    let key_val_pairs = s.split("\n");
+    for key_val_pair in key_val_pairs {
+        let sep = key_val_pair.split(":");
+        let key = sep[0];
+        let val = sep[1];
+        reg_array[key] = val;
+    }
+}
+
+
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,6 +1,6 @@
 use log::error;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct REGISTER {
     pub content: i32,
     pub locked: bool,
@@ -35,13 +35,22 @@ impl REGISTER {
     }
 }
 
-pub fn register_from_string(s: &str, reg_array: &[REGISTER]) {
-    let key_val_pairs = s.split("\n");
+pub fn register_from_string(s: &str, reg_array: &mut [REGISTER]) {
+    let key_val_pairs: Vec<&str> = s.split("\n").collect();
     for key_val_pair in key_val_pairs {
-        let sep = key_val_pair.split(":");
-        let key = sep[0];
-        let val = sep[1];
-        reg_array[key] = val;
+        if key_val_pair.is_empty() {
+            continue;
+        }
+        let sep: Vec<&str> = key_val_pair.split(":").collect();
+        let key = sep[0].parse::<usize>().unwrap();
+        let val = sep[1].parse::<i32>().unwrap();
+        let locked = sep[2];
+        reg_array[key].content = val;
+        if locked == "1" {
+            reg_array[key].locked = true;
+        } else {
+            reg_array[key].locked = false;
+        }
     }
 }
 
@@ -97,5 +106,13 @@ mod tests {
         assert_eq!(test_reg.content, 3);
         assert_eq!(sucessful, false);
 
+    }
+
+    #[test]
+    fn test_register_from_string() {
+        let s = "0:5:1\n1:10:0";
+        let mut m = [REGISTER{ content: 0, locked: false }; 2];
+        register_from_string(s, &mut m);
+        assert_eq!(m[0], REGISTER{ content: 5, locked: true });
     }
 }

--- a/src/register.rs
+++ b/src/register.rs
@@ -35,7 +35,7 @@ impl REGISTER {
     }
 }
 
-pub fn register_from_string(s: &str, reg_array: *[REGISTER]) {
+pub fn register_from_string(s: &str, reg_array: &[REGISTER]) {
     let key_val_pairs = s.split("\n");
     for key_val_pair in key_val_pairs {
         let sep = key_val_pair.split(":");

--- a/src/register.rs
+++ b/src/register.rs
@@ -35,7 +35,7 @@ impl REGISTER {
     }
 }
 
-fn register_from_string(s: &str, reg_array: *[REGISTER]) {
+pub fn register_from_string(s: &str, reg_array: *[REGISTER]) {
     let key_val_pairs = s.split("\n");
     for key_val_pair in key_val_pairs {
         let sep = key_val_pair.split(":");


### PR DESCRIPTION
This pull request adds support for Perling Register File importing using ``--reg REGISTERFILENAME``.
A simple register file looks like this
```
1:23:1
2:34:0
```
```
[register_index]:[register_value]:[locked(1/0)]
```